### PR TITLE
Fixes to allow python3.8 tap-tester default - upgrade pylint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-recurly
             source /usr/local/share/virtualenvs/tap-recurly/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install -U pip setuptools
             pip install .[dev]
       - run:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-recurly/bin/activate
-            make test
+            make lint
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ jobs:
             pip install -U pip setuptools
             pip install .[dev]
       - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json tap_recurly/schemas/*.json
+      - run:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-recurly/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 #
 # Default.
 #
@@ -10,7 +9,7 @@ default: build
 #
 
 # Build.
-build: 
+build:
 	@pip3 install .
 
 # Dev.
@@ -21,12 +20,12 @@ dev:
 release:
 	@python3 setup.py sdist upload
 
-# Test.
-test:
+# Lint.
+lint:
 	pylint tap_recurly -d missing-docstring,too-few-public-methods,invalid-name,too-many-instance-attributes,too-many-arguments
 
 # Discover.
-disc: 
+disc:
 	@tap-recurly -c config.json --discover > catalog.json
 
 #
@@ -37,5 +36,5 @@ disc:
 .PHONY: dev
 .PHONY: release
 .PHONY: schema
-.PHONY: test
+.PHONY: lint
 .PHONY: disc

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(name='tap-recurly',
       ],
       extras_require={
         'dev': [
-            'ipdb==0.11',
-            'pylint==2.3.0',
+            'ipdb==0.13.7',
+            'pylint==2.7.2',
         ]
       },
       entry_points='''


### PR DESCRIPTION
# Description of change
Fixes to allow python3.8 tap-tester default - upgrade pylint

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
