### PR TITLE
don't build failures to main slack channel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,10 @@ workflows:
   commit:
     jobs:
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tap-tester-user
+
   build_daily:
     triggers:
       - schedule:
@@ -51,4 +54,6 @@ workflows:
                 - master
     jobs:
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tap-tester-user


### PR DESCRIPTION
# Description of change
Don't send build failures to main slack channel.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
