### PR TITLE
Usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Messages are written to standard output following the Singer specification. The 
 - Plans Add Ons
 - Subscriptions
 - Transactions
+- Usages
 
 ### Full Table
 

--- a/tap_recurly/recurly.py
+++ b/tap_recurly/recurly.py
@@ -20,7 +20,7 @@ class Recurly():
     """ Simple wrapper for Recurly. """
 
     def __init__(self, subdomain, api_key, start_date=None, user_agent=None, quota_limit=100):
-        self.headers = {'Accept': 'application/vnd.recurly.v2018-08-09'}
+        self.headers = {'Accept': 'application/vnd.recurly.v2021-02-25'}
         self.site_id = "subdomain-{subdomain}".format(subdomain=subdomain)
         self.user_agent = user_agent
         self.start_date = start_date
@@ -142,6 +142,17 @@ class Recurly():
         url += "?limit={limit}&sort={column_name}&order=asc"
         url = url.format(site_id=self.site_id,
                          subscription_id=subscription_id,
+                         limit=self.limit,
+                         column_name=column_name)
+        for item in self._get_all(url):
+            yield item
+
+    def usages(self, subscription_id, add_on_id, column_name):
+        url = "sites/{site_id}/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage"
+        url += "?billing_status=all&limit={limit}&sort={column_name}&order=asc"
+        url = url.format(site_id=self.site_id,
+                         subscription_id=subscription_id,
+                         add_on_id=add_on_id,
                          limit=self.limit,
                          column_name=column_name)
         for item in self._get_all(url):

--- a/tap_recurly/schemas/usages.json
+++ b/tap_recurly/schemas/usages.json
@@ -1,0 +1,144 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": ["null", "string"]
+    },
+    "object": {
+      "type": ["null", "string"],
+      "title": "Object type"
+    },
+    "merchant_tag": {
+      "type": ["null", "string"],
+      "description": "Custom field for recording the id in your own system associated with the usage, so you can provide auditable usage displays to your customers using a GET on this endpoint."
+    },
+    "amount": {
+      "type": ["null", "number"],
+      "format": "float",
+      "description": "The amount of usage. Can be positive, negative, or 0. If the Decimal Quantity feature is enabled, this value will be rounded to nine decimal places.  Otherwise, all digits after the decimal will be stripped. If the usage-based add-on is billed with a percentage, your usage should be a monetary amount formatted in cents (e.g., $5.00 is \"500\")."
+    },
+    "usage_type": {
+      "type": ["null", "string"],
+      "enum": ["price", "percentage"],
+      "title": "Usage Type",
+      "description": "Type of usage, returns usage type if `add_on_type` is `usage`."
+    },
+    "tier_type": {
+      "type": ["null", "string"],
+      "title": "Tier type",
+      "description": "The pricing model for the add-on.  For more information,\n[click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our\n[Guide](https://recurly.com/developers/guides/item-addon-guide.html) for an overview of how\nto configure quantity-based pricing models.\n",
+      "default": "flat",
+      "enum": ["flat", "tiered", "stairstep", "volume"]
+    },
+    "tiers": {
+      "type": ["null", "array"],
+      "title": "Tiers",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ending_quantity": {
+            "type": ["null", "integer"],
+            "title": "Ending quantity",
+            "minimum": 1,
+            "maximum": 999999999,
+            "default": null,
+            "description": "Ending quantity for the tier.  This represents a unit amount for unit-priced add ons. Must be left empty if it is the final tier."
+          },
+          "unit_amount": {
+            "type": ["null", "number"],
+            "format": "float",
+            "title": "Unit amount",
+            "minimum": 0,
+            "maximum": 1000000,
+            "description": "Allows up to 2 decimal places. Optionally, override the tiers' default unit amount. If add-on's `add_on_type` is `usage` and `usage_type` is `percentage`, cannot be provided."
+          },
+          "unit_amount_decimal": {
+            "type": ["null", "string"],
+            "title": "Unit amount decimal",
+            "description": "Allows up to 9 decimal places.  Optionally, override tiers' default unit amount.\nIf `unit_amount_decimal` is provided, `unit_amount` cannot be provided.\nIf add-on's `add_on_type` is `usage` and `usage_type` is `percentage`, cannot be provided.\n"
+          },
+          "usage_percentage": {
+            "type": ["null", "string"],
+            "title": "Usage Percentage",
+            "description": "(deprecated) -- Use the percentage_tiers object instead.",
+            "deprecated": true
+          }
+        }
+      },
+      "description": "The tiers and prices of the subscription based on the usage_timestamp. If tier_type = flat, tiers = []"
+    },
+    "percentage_tiers": {
+      "type": ["null", "array"],
+      "title": "Percentage Tiers",
+      "items": {
+        "type": "object",
+        "properties": {
+          "ending_amount": {
+            "type": ["null", "number"],
+            "format": "float",
+            "title": "Ending amount",
+            "minimum": 1,
+            "maximum": 9999999999999.99,
+            "default": null,
+            "description": "Ending amount for the tier. Allows up to 2 decimal places. Must be left empty if it is the final tier."
+          },
+          "usage_percentage": {
+            "type": ["null", "string"],
+            "title": "Usage Percentage",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "The percentage taken of the monetary amount of usage tracked.\nThis can be up to 4 decimal places represented as a string.\n"
+          }
+        }
+      },
+      "description": "The percentage tiers of the subscription based on the usage_timestamp. If tier_type = flat, percentage_tiers = []"
+    },
+    "measured_unit_id": {
+      "type": ["null", "string"],
+      "description": "The ID of the measured unit associated with the add-on the usage record is for."
+    },
+    "recording_timestamp": {
+      "type": ["null", "string"],
+      "format": "date-time",
+      "description": "When the usage was recorded in your system."
+    },
+    "usage_timestamp": {
+      "type": ["null", "string"],
+      "format": "date-time",
+      "description": "When the usage actually happened. This will define the line item dates this usage is billed under and is important for revenue recognition."
+    },
+    "usage_percentage": {
+      "type": ["null", "number"],
+      "format": "float",
+      "title": "Usage Percentage",
+      "description": "The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0."
+    },
+    "unit_amount": {
+      "type": ["null", "number"],
+      "format": "float",
+      "title": "Unit price"
+    },
+    "unit_amount_decimal": {
+      "type": ["null", "string"],
+      "title": "Unit Amount Decimal",
+      "minimum": 0,
+      "maximum": 1000000,
+      "description": "Unit price that can optionally support a sub-cent value."
+    },
+    "billed_at": {
+      "type": ["null", "string"],
+      "format": "date-time",
+      "description": "When the usage record was billed on an invoice."
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time",
+      "description": "When the usage record was created in Recurly."
+    },
+    "updated_at": {
+      "type": ["null", "string"],
+      "format": "date-time",
+      "description": "When the usage record was billed on an invoice."
+    }
+  }
+}

--- a/tests/base.py
+++ b/tests/base.py
@@ -101,6 +101,11 @@ class RecurlyBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"collected_at"},
             },
+            'usages': {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"recording_timestamp"},
+            },
         }
 
     def expected_streams(self):


### PR DESCRIPTION
# Description of change
add [usages](https://docs.recurly.com/docs/usage-based-billing) stream.
the new schema come from the [Recurly openAPI specification](https://recurly.com/developers/api/spec/v2021-02-25.yaml).

# Manual QA steps
 - add usage to a subscription add on https://recurly.com/developers/api/v2021-02-25/index.html#operation/create_usage
 - run the tap

I tried that on our own domain and it was working as expected.
 
# Risks
 - api version is updated to be able to have usages. Tell me if you are interested to update current schema to follow this new version of the API (maybe in another pull request)? 
 
# Rollback steps
 - revert this branch
