### PR TITLE
Add retry mechanism for the intermittent value error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.4
+  - Retry mechanism for the intermittent value error [#18](https://github.com/singer-io/tap-recurly/pull/18)
+
 ## 1.0.3
   - Fix miscellaneous pylint errors [#16](https://github.com/singer-io/tap-recurly/pull/16)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-recurly',
-      version='1.0.3',
+      version='1.0.4',
       description='Singer.io tap for extracting data from the Recurly API',
       author='Stitch',
       url='http://github.com/singer-io/tap-recurly',

--- a/tap_recurly/recurly.py
+++ b/tap_recurly/recurly.py
@@ -47,8 +47,8 @@ class Recurly():
 
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.RetryError,
-                            standard_json.JSONDecodeError,
-                            RequestsJSONDecodeError),
+                           standard_json.JSONDecodeError,
+                           RequestsJSONDecodeError),
                           on_backoff=retry_handler,
                           max_tries=5)
     def _get(self, path):

--- a/tap_recurly/recurly.py
+++ b/tap_recurly/recurly.py
@@ -44,7 +44,7 @@ class Recurly():
 
 
     @backoff.on_exception(backoff.expo,
-                          requests.exceptions.RetryError,
+                          (requests.exceptions.RequestException, ValueError),
                           on_backoff=retry_handler,
                           max_tries=5)
     def _get(self, path):
@@ -60,7 +60,16 @@ class Recurly():
         limit_limit = response.headers.get('X-RateLimit-Limit')
         limit_reset_time = response.headers.get('X-RateLimit-Reset')
         self.check_rate_limit(limit_remaining, limit_limit, limit_reset_time)
-        return response.json()
+        try:
+            return response.json()
+        except ValueError:
+            logger.error(
+                "Invalid JSON response for uri=%s | status=%s | content_type=%s",
+                uri,
+                response.status_code,
+                response.headers.get("Content-Type")
+            )
+            raise
 
 
     def _get_all(self, path):

--- a/tap_recurly/recurly.py
+++ b/tap_recurly/recurly.py
@@ -6,8 +6,10 @@ from urllib import parse
 import logging
 import time
 import backoff
+import json
 import requests
 from requests.auth import HTTPBasicAuth
+from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 
 logger = logging.getLogger()
 
@@ -44,7 +46,9 @@ class Recurly():
 
 
     @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.RequestException, ValueError),
+                          (requests.exceptions.RetryError,
+                            json.JSONDecodeError,
+                            RequestsJSONDecodeError),
                           on_backoff=retry_handler,
                           max_tries=5)
     def _get(self, path):

--- a/tap_recurly/recurly.py
+++ b/tap_recurly/recurly.py
@@ -5,8 +5,8 @@
 from urllib import parse
 import logging
 import time
+import json as standard_json
 import backoff
-import json
 import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
@@ -47,7 +47,7 @@ class Recurly():
 
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.RetryError,
-                            json.JSONDecodeError,
+                            standard_json.JSONDecodeError,
                             RequestsJSONDecodeError),
                           on_backoff=retry_handler,
                           max_tries=5)


### PR DESCRIPTION
# Description of change
This PR adds a retry mechanism to handle intermittent JSONDecodeError exceptions when parsing JSON responses from the Recurly API. The change catches JSON parsing failures, logs relevant diagnostic information, and allows the backoff decorator to retry the request.

- Expanded the backoff exception handler to catch JSONDecodeError in addition to requests.exceptions.RetryError
- Added try-except block around JSON parsing with detailed error logging including URI, status code, and content type

JIRA Ticket - [SUPPORT-7846](https://qlik-dev.atlassian.net/browse/SUPPORT-7846)
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
